### PR TITLE
fix Torguard's new API

### DIFF
--- a/usr/bin/tginit
+++ b/usr/bin/tginit
@@ -19,60 +19,64 @@
 #	sed -i "s/YourVPNPassword/${TGPASS}/" /usr/bin/tginstall
 #	sed -i "s/TorguardServer1:1443 TorguardServer2:1443 TorguardServer3:1443/${TGSERVERLIST}/" /usr/bin/tginstall
 #
+getmyipTorGuard () {
+	#$1 - VPN Username $2 - VPN Password $3 - Wireguard Endpoint $4 - Wireguard Port $5 - My wireguard public key
+	URL="https://updates.torguard.biz/cgi-bin/whatismyip.pl"
+	MYIPADDRESS=$(${DBINAPI} ${URL})
+}
+
 # Wireguarrd key generation
 genwgkey () {
 	PRIVATE=$(wg genkey)
 	PUBLIC=$(echo "${PRIVATE}" | wg pubkey)
+	APIPUBKEY=$(echo "${PUBLIC}" | sed 's/=/%3D/')
 }
 
-# Get TorGuard server connection info with wget
-wgetinfo () {
+createwgpubkeys () {
+	PUBLIC=$(echo "${PRIVATE}" | wg pubkey)
+	APIPUBKEY=$(echo "${PUBLIC}" | sed 's/=/%3D/')
+}
+
+createapidemoscript () {
 	#$1 - VPN Username
 	#$2 - VPN Password
 	#$3 - Wireguard Endpoint
 	#$4 - Wireguard Port
 	#$5 - My wireguard public key
+	#$6 - Output filename
 	#wget -O $6 --no-check-certificate https://$1:$2@$3:$4/api/v1/setup?public-key=$5
 	URL="https://${1}:${2}@${3}:${4}/api/v1/setup?public-key=${5}"
-	echo "API: ${URL}"
-	TGINFO=$(wget --no-check-certificate -qO- ${URL})
+	cat <<EOF_cronjobscript | tee $6
+#!/bin/sh
+${DBINAPI} ${URL}
+EOF_cronjobscript
+	echo "Make cronjob script executable: $6"
+	chmod +x $6
 }
 
 # Get TorGuard server connection info with curl
-curlinfo () {
+downloadinfo () {
 	#$1 - VPN Username $2 - VPN Password $3 - Wireguard Endpoint $4 - Wireguard Port $5 - My wireguard public key
 	URL="https://${1}:${2}@${3}:${4}/api/v1/setup?public-key=${5}"
 	echo "API: https://$1:$2@$3:$4/api/v1/setup?public-key=${5}"
-	TGINFO=$(curl -k ${URL})
+	TGINFO=$($DBINAPI ${URL})
 }
 
 # get connection information from torguard server and set variables
 gettginfo () {
-	if [ -f /usr/bin/curl ]; then
-		echo "curl: OK - found: /usr/bin/curl"
-		curlinfo "${1}" "${2}" "${3}" "${4}" "${5}"
-	elif [ -f /usr/bin/wget ]; then
-		echo "wget: OK - found: /usr/bin/wget"
-		wgetinfo "${1}" "${2}" "${3}" "${4}" "${5}"
-	else
-		echo "ERROR: script requires curl or wget with ssl support
-		Install curl with:
+	downloadinfo "${1}" "${2}" "${3}" "${4}" "${5}"
+	createapidemoscript "${1}" "${2}" "${3}" "${4}" "${5}" "${TGAPITEST}"
+}
 
-			opkg update
-			opkg install curl
-
-		or wget-ssl with:
-
-			opkg update
-			opkg install wget-ssl"
-		exit
-	fi
+# Delete wireguard interface
+deletewginterface () {
+	echo "delete existing default peer 0 and commit changes..." && uci delete network.@wireguard_${1}[0] && uci commit network
+	echo "delete existing wireguard interface and commit changes..." && uci delete network.${1} && uci commit network
+	echo "restart network..." && /etc/init.d/network restart
 }
 
 # Add wireguard interface
 addwginterface () {
-	echo "delete existing default peer 0 and commit changes..." && uci delete network.@wireguard_${1}[0] && uci commit network
-	echo "delete existing wireguard interface and commit changes..." && uci delete network.${1} && uci commit network
 	echo "add new network interface (torguard wireguard interface)" && uci add network interface
 	echo "rename new interface to: ${1}" && uci rename network.@interface[-1]=${1}
 	echo "set new interface's proto: wireguard" && uci set network.@interface[-1].proto='wireguard'
@@ -97,8 +101,37 @@ addwginterface () {
 	uci commit firewall
 }
 
+# use curl or wget
+if [ -f /usr/bin/curl ]; then
+  echo "curl: OK - found: /usr/bin/curl"
+  DBIN="/usr/bin/curl -o"
+  DBINAPI="/usr/bin/curl -k"
+elif [ -f /usr/bin/wget ]; then
+  echo "wget: OK - found: /usr/bin/wget, download init script"
+  DBIN="/usr/bin/wget --no-check-certificate -O"
+  DBINAPI="/usr/bin/wget --no-check-certificate -qO-"
+else
+  echo "curl: not found"
+  echo "wget: not found"
+  echo "try to install curl from opkg..."
+  opkg update && opkg install curl
+fi
+
+# initialize vars (**TODO** delete them after cleanup)
+PRIVATE=""
+PUBLIC=""
+APIPUBKEY=""
+ENDPOINT=""
+ENDPOINTPORT=""
+TGINFO=""
+DESCRIPTION=""
+MYIPADDRESS=""
+
+# create torguard api server test script with current settings
+TGAPITEST="/usr/bin/tgapitest"
+
 # Each server in a string must be provided by server and port "server:port" and separated by space "srv1:1234 srv2:5678"
-TGSERVERLIST="${13}" # TorGuard Server List separated by space, "srv1:1234 srv2:5678"
+TGSERVERLIST="${14}" # TorGuard Server List separated by space, "srv1:1234 srv2:5678"
 # TorGuard credentials
 VPNUSERNAME="${1}"		# TorGuard VPN username
 VPNPASS="${2}"			# TorGuard VPN password
@@ -110,11 +143,20 @@ MTU="${7}"			# Optional. Maximum Transmission Unit of tunnel interface.
 # Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, starting with 0x. Default: 0xFE
 if [ -z ${8+x} ]; then echo "FWMARK was not submited, using dummy value 0xFE" FWMARK="0xFE"; else FWMARK="${8}"; fi
 KEEPALIVE="${9}"		# Optional. Seconds between keep alive messages. Default is 0 (disabled). Recommended value if this device is behind a NAT is 25.
-USEBUILTINIPV6="${10}"		# Use builtin IPv6-management	0 to disable, 1 to enable
+USEBUILTINIPV6="${10}"	# Use builtin IPv6-management	0 to disable, 1 to enable
 ROUTEALLOWEDIPS="${11}"	# Route allowed IPs, 0 to disable, 1 to enable
-FIREWALLZONE="${12}"		# Assign firewall-zone, 1 is wan, 0 is lan, default: 1
+FIREWALLZONE="${12}"	# Assign firewall-zone, 1 is wan, 0 is lan, default: 1
+TGPRIVKEY="${13}"		# this is your peers wireguard private key, if not passed/empty, new keypairs will be generated
 
-echo "
+if [ -n "$TGPRIVKEY" ]; then
+    echo "API key from /etc/config/torguard OK - ${TGPRIVKEY}"
+	PRIVATE="${TGPRIVKEY}"
+	createwgpubkeys
+else
+	echo "create new private and public keys..." && genwgkey
+fi
+
+echo "Passed vars:
 TorGuard VPN username:					${1}
 TorGuard VPN password:					${2}
 Wireguard interface name:				${3}
@@ -126,15 +168,9 @@ Maximum Transmission Unit of tunnel:	${7}
 Seconds between keep alive messages:	${9}
 Use builtin IPv6-management:			${10}
 Route allowed IPs:						${11}
-TorGuard Server List:					${12}"
-
-# initialize vars (**TODO** delete them after cleanup)
-PRIVATE=""
-PUBLIC=""
-ENDPOINT=""
-ENDPOINTPORT=""
-TGINFO=""
-DESCRIPTION=""
+TorGuard firewall zone:					${12}
+TorGuard wireguard private key:			${13}
+TorGuard Server List:					${14}"
 
 TMPPORT=$(( $LISTENPORT - 1 ))
 TMPFWMARK=$(printf "%x\n" $(( $(printf "%d\n" ${FWMARK}) - 1 )))
@@ -146,11 +182,23 @@ for i in ${TGSERVERLIST}; do
 	TMPFWMARK=$(printf "%x\n" $(( $(printf "%d\n" 0x${TMPFWMARK}) + 1 ))) && echo "FWMARK: $TMPFWMARK"
 	TMPWGIFNR=$(( $TMPWGIFNR + 1 )) && echo "Wireguard interface number: $TMPWGIFNR"
 	DESCRIPTION="${WGINTERFACE}${WGIFNR} (TorGuard)" && echo "Description: $DESCRIPTION"
-	ZONEINTERFACES=$(uci get firewall.@zone[${FIREWALLZONE}].network) && echo "Firewall zone: $ZONEINTERFACES"
+	ZONEINTERFACES=$(uci get firewall.@zone[${FIREWALLZONE}].network | sed "s/${WGINTERFACE}${WGIFNR}//g") && echo "Firewall zone: $ZONEINTERFACES"
 	ENDPOINT=$(echo $i | awk -F'[:]' '{print $1}') && echo "Endpoint host: $ENDPOINT"
 	ENDPOINTPORT=$(echo $i | awk -F'[:]' '{print $2}') && echo "Endpoint port: $ENDPOINTPORT"
-	echo "create new private and public keys" && genwgkey && echo "YOUR NEW PRIVATE AND PUBLIC KEYS:" && echo "Private: ${PRIVATE}" && echo "Public:  ${PUBLIC}"
-	gettginfo "${VPNUSERNAME}" "${VPNPASS}" "${ENDPOINT}" "${ENDPOINTPORT}" "${PUBLIC}"
+	echo "delete wireguard interface with same name... ($i)"
+	# delete current interface for a case that IP is not
+	deletewginterface "${WGINTERFACE}${WGIFNR}"
+	getmyipTorGuard && echo "my current IP address after deletion of ${WGINTERFACE}${WGIFNR}: ${MYIPADDRESS}"
+	# from here internet connection must be present
+	if [ -n "$TGPRIVKEY" ]; then
+		echo "using API key from /etc/config/torguard: OK (${TGPRIVKEY})"
+		PRIVATE="${TGPRIVKEY}"
+		createwgpubkeys
+	else
+		echo "create new private and public keys..." && genwgkey
+	fi
+	echo "USED PUBLIC AND API KEYS:" && echo "Private: ${PRIVATE}" && echo "Public:  ${PUBLIC}" && echo "API Public key:${APIPUBKEY}"
+	gettginfo "${VPNUSERNAME}" "${VPNPASS}" "${ENDPOINT}" "${ENDPOINTPORT}" "${APIPUBKEY}"
 	WGPUBLIC=$(echo ${TGINFO} | awk -F'[,]' '{print $1}' | awk -F'[:]' '{print $2}' | sed 's/"//g') && echo "Public key: ${WGPUBLIC}"
 	SERVERIP=$(echo ${TGINFO} | awk -F'[,]' '{print $2}' | awk -F'[:]' '{print $2}' | sed 's/"//g') && echo "Peer server: ${SERVERIP}"
 	CLIENTIP=$(echo ${TGINFO} | awk -F'[,]' '{print $3}' | awk -F'[:]' '{print $2}' | sed 's/"//g') && echo "IP Addresses: ${CLIENTIP}"
@@ -165,5 +213,6 @@ done
 
 /etc/init.d/firewall restart
 /etc/init.d/network restart
+getmyipTorGuard && echo "my current IP address after creation of ${WGINTERFACE}${WGIFNR}: ${MYIPADDRESS}"
 
 echo "Torguard wireguard initialization finished, please reboot to complete"

--- a/usr/bin/tginit-uci-basic
+++ b/usr/bin/tginit-uci-basic
@@ -35,6 +35,9 @@ uci set torguard.@wireguard_tg0[-1].endpoint_host='173.244.200.119'
 uci set torguard.@wireguard_tg0[-1].endpoint_port='1443'
 uci set torguard.@wireguard_tg0[-1].persistent_keepalive='25'
 uci set torguard.@wireguard_tg0[-1].route_allowed_ips='1'
+uci set torguard.@wireguard_tg0[-1].tgprivkey=''
+uci set torguard.@wireguard_tg0[-1].wgapipubkey=''
+uci set torguard.@wireguard_tg0[-1].upgrade='0'
 
 uci add torguard specification
 uci add_list torguard.@specification[-1].proto='udp'

--- a/usr/bin/tginstall
+++ b/usr/bin/tginstall
@@ -1,12 +1,19 @@
 #!/bin/sh
 # Copyright (c) 2020 TorGuard forum user 19807409
-# tginstall (Optional: [TorGuardConfigInterface] [WireGuardInterfaceNumber] [Questionarrie] [InstallSpeedperf])
-# Example: tginstall tg0 0 n n
+# tginstall (Optional: [TorGuardConfigInterface] [WireGuardInterfaceNumber] [Questionarrie] [InstallSpeedperf] [HidePassword])
+# Example: tginstall tg0 0 n n n
 # ℹ️ check submitted vars
-if [ -z ${1+x} ]; then TGIF="tg0" && echo "TorGuard Interface was not submited, using default: ${TGIF}"; else TGIF="${1}" && echo "TorGuard Interface submitted: ${TGIF}"; fi
-if [ -z ${2+x} ]; then WGIFNR="0" && echo "WireGuard Interface Number was not submited, using default: ${WGIFNR}"; else WGIFNR="${2}" && echo "WireGuard Interface Number submitted: ${WGIFNR}"; fi
-if [ -z ${3+x} ]; then question="n" && echo "Questionarrie not submited, using default: ${question}"; else question="${3}" && echo "Questionarrie submitted: ${question}"; fi
-if [ -z ${4+x} ]; then setspeedperf="n" && echo "Install speedperf not submited, using default: ${setspeedperf}"; else setspeedperf="${4}" && echo "Install speedperf submitted: ${setspeedperf}"; fi
+#if [ -z ${1+x} ]; then TGIF="tg0" && echo "TorGuard Interface was not submited, using default: ${TGIF}"; else TGIF="${1}" && echo "TorGuard Interface submitted: ${TGIF}"; fi
+#if [ -z ${2+x} ]; then WGIFNR="0" && echo "WireGuard Interface Number was not submited, using default: ${WGIFNR}"; else WGIFNR="${2}" && echo "WireGuard Interface Number submitted: ${WGIFNR}"; fi
+#if [ -z ${3+x} ]; then question="n" && echo "Questionarrie not submited, using default: ${question}"; else question="${3}" && echo "Questionarrie submitted: ${question}"; fi
+#if [ -z ${4+x} ]; then setspeedperf="n" && echo "Install speedperf not submited, using default: ${setspeedperf}"; else setspeedperf="${4}" && echo "Install speedperf submitted: ${setspeedperf}"; fi
+
+# Default settings
+if [ -n "${1}" ]; then TGIF="${1}"; else TGIF="tg0"; fi
+if [ -n "${2}" ]; then WGIFNR="${2}"; else WGIFNR="0";fi
+if [ -n "${3}" ]; then question="${3}"; else question="n";fi
+if [ -n "${4}" ]; then setspeedperf="${4}";else setspeedperf="n";fi
+if [ -n "${5}" ]; then HidePassword="${5}";else HidePassword="n";fi
 
 FAQMSG="### ℹ️ How to FAQ - Torguard wireguard server ###
 How to show your configs
@@ -26,15 +33,30 @@ How to set your configs
 After changing value with uci, you have to commit changes
 - Commit changes:                 uci commit torguard"
 
+TORGUARDAPIPRIVKEYINFO="PRIVATE KEY INFO:Please use TorGuard wireguard tool or connect with with TorGuard client on any other machine, then get your private key with:
+
+  wg showconf torguard-wg | grep PrivateKey
+
+Example: iFOcWqNA3sYlUwbwHmil1oV4MsvbczA0YchzjDBjO38="
+
 INVALIDCHOICEMSG1="invalid choice, please use only y or Y for yes and n or N for no"
+
+# OPKG Dependencies
+DEPS="kmod-wireguard wireguard-tools"
+DEPSOPTIONAL="ipset curl"
+DEPSSPEEDPERF="iperf3"
+DEPSFIRSTINSTALL="$DEPS $DEPSOPTIONAL"
+DEPSASKINSTALL=""
 
 # use curl or wget
 if [ -f /usr/bin/curl ]; then
   echo "curl: OK - found: /usr/bin/curl"
   DBIN="/usr/bin/curl -o"
+  DBINAPI="/usr/bin/curl -k"
 elif [ -f /usr/bin/wget ]; then
   echo "wget: OK - found: /usr/bin/wget, download init script"
   DBIN="/usr/bin/wget -O"
+  DBINAPI="/usr/bin/wget --no-check-certificate -qO-"
 else
   echo "curl: not found"
   echo "wget: not found"
@@ -74,34 +96,47 @@ else
 fi
 
 if [ -f /etc/config/torguard ]; then
-  echo "Found: /etc/config/torguard"
+  echo "Found: /etc/config/torguard (unattended setup)"
+  question="n"
+  setspeedperf="n"
 else
   question="y"
   echo "Initialize torguard config file"
   tginit-uci-basic
-  echo "Please set your torguard credentials which are require for API usage"
+  echo "Please set your torguard credentials which are require for API usage..."
   read -p 'Set Username: ' TORGUARDUSERNAME
-  #read -sp 'Set Password: ' TORGUARDPASS
-  read -p 'Set Password: ' TORGUARDPASS 
-  read -p "Continue (y/n)?" setcred
+  case "$HidePassword" in 
+    y|Y ) read -sp 'Set Password: ' TORGUARDPASS;;
+    n|N ) read -p 'Set Password: ' TORGUARDPASS;;
+    * ) echo "Warning: invalid HidePassword value was set/passed, using default value to show password"; read -p 'Set Password: ' TORGUARDPASS;;
+  esac
+  echo "Please confirm if your password and username are correct:";echo "Entered Username: ${TORGUARDUSERNAME}";echo "Entered Password: ${TORGUARDPASS}"
+  read -p "Are entered username/password correct and do you want to continue (y/n)? " setcred
   case "$setcred" in 
     y|Y ) uci set torguard.@credentials_${TGIF}[0].username="$TORGUARDUSERNAME";uci set torguard.@credentials_${TGIF}[0].password="$TORGUARDPASS";uci commit torguard;;
-    n|N ) echo "user abort, script finished"; exit;;
+    n|N ) echo "user abort because entered password/username combinatino is incorrect, script finished and exiting ..."; exit;;
     * ) echo "${INVALIDCHOICEMSG1}"; exit;;
   esac
-  read -p "Do you want to set custom IP (y/n)? (default New York server will be used if custom IP is not set)" askserv
+  echo "ℹ️ - By not setting your your custom IP, New York's server will be used as default"
+  read -p "Do you want to set custom IP (y/n)? " askserv
   case "$askserv" in 
-    y|Y ) read -p "Set your server: " setserv
-          uci set torguard.@wireguard_${TGIF}[0].endpoint_host="$setserv";;
+    y|Y ) read -p "Set your server ip address: " setserv;echo "${TORGUARDAPIPRIVKEYINFO}";read -p 'Set your wireguard private key: ' TORGUARDAPIPRIVKEY;uci set torguard.@wireguard_${TGIF}[0].endpoint_host="$setserv";uci set torguard.@wireguard_${TGIF}[0].wgapipubkey=$(echo "${TORGUARDAPIPRIVKEY}" | wg pubkey | sed 's/=/%3D/');;
     n|N ) echo "using default script server";;
     * ) echo "${INVALIDCHOICEMSG1}"; exit;;
   esac
+  read -p "Do you want upgrade dependencies on every run (y/n)? " askupgrade;
+  case "$askupgrade" in 
+    y|Y ) uci set torguard.@wireguard_${TGIF}[0].upgrade="1";;
+    n|N ) echo "disabling upgrade on every run...";uci set torguard.@wireguard_${TGIF}[0].upgrade="0";;
+    * ) echo "${INVALIDCHOICEMSG1}"; exit;;
+  esac
+  read -p "Do you want to install/reinstall required dependencies (y/n)? " askinstalldependencies
+  case "$askinstalldependencies" in 
+    y|Y ) opkg update && opkg install ${DEPSFIRSTINSTALL};;
+    n|N ) echo "WARNING: skipping installation of required packages, script will continue but will end in errors";;
+    * ) echo "${INVALIDCHOICEMSG1}"; exit;;
+  esac
 fi
-
-# OPKG Dependencies
-DEPS="kmod-wireguard wireguard-tools"
-DEPSOPTIONAL="ipset"
-DEPSSPEEDPERF="iperf3"
 
 # 🔐 TorGuard credentials
 TGUSER=$(uci get torguard.@credentials_${TGIF}[0].username)
@@ -115,10 +150,14 @@ NOHOSTROUTE=$(uci torguard.@interface_${TGIF}[0].nohostroute)
 LISTENPORT=$(uci get torguard.@interface_${TGIF}[0].listen_port)
 MTU=$(uci get torguard.@interface_${TGIF}[0].mtu)
 FWMARK=$(uci get torguard.@interface_${TGIF}[0].fwmark)
-KEEPALIVE=$(uci get torguard.@interface_${TGIF}[0].persistent_keepalive)
 DELEGATE=$(uci get torguard.@interface_${TGIF}[0].delegate)
 ROUTEALLOWEDIPS=$(uci get torguard.@wireguard_${TGIF}[0].route_allowed_ips)
-ENDPOINT=$(uci get torguard.@wireguard_${TGIF}[0].endpoint_host):$(uci get torguard.@wireguard_${TGIF}[0].endpoint_port)
+KEEPALIVE=$(uci get torguard.@wireguard_${TGIF}[0].persistent_keepalive)
+ENDPOINT=$(uci get torguard.@wireguard_${TGIF}[0].endpoint_host)
+WGPRIVKEY=$(uci get torguard.@wireguard_${TGIF}[0].tgprivkey)
+WGAPIPUBKEY=$(uci get torguard.@wireguard_${TGIF}[0].wgapipubkey)
+WGUPGRADE=$(uci get torguard.@wireguard_${TGIF}[0].upgrade)
+
 # 🛡️ Torguard server [host]:[port]
 ENPOINTPORT=$(uci get torguard.@wireguard_${TGIF}[0].endpoint_port)
 
@@ -147,8 +186,12 @@ Route Allowed IPs:              ${ROUTEALLOWEDIPS}
 🛡️ Torguard wireguard server: 
 Endpoint host:                  ${ENDPOINT}
 Endpoint host port:             ${ENPOINTPORT}
+Wireguard priv key:             ${WGPRIVKEY}
+Wireguard api pub key:          ${WGAPIPUBKEY}
 
-Install openwrt dependencies:   ${DEPS}"
+# Openwrt update/upgrade options
+Openwrt dependencies:           ${DEPS}
+Upgrade dependencies:           ${WGUPGRADE}"
 
 case "$question" in
   y|Y ) read -p "Continue (y/n)?" answer;read -p "Do you want to install iperf3 and speedperf scripts (y/n)?" setspeedperf;;
@@ -158,8 +201,8 @@ esac
 
 case "$answer" in 
   y|Y ) echo "starting $0...";
-        opkg update && opkg install ${DEPS} ${DEPSOPTIONAL};
-        tginit "${TGUSER}" "${TGPASS}" "${WGINTERFACE}" "${WGIFNR}" "${NOHOSTROUTE}" "${LISTENPORT}" "${MTU}" "${FWMARK}" "${KEEPALIVE}" "${DELEGATE}" "${ROUTEALLOWEDIPS}" "${FIREWALLZONE}" "${ENDPOINT}:${ENPOINTPORT}";;
+        #opkg update && opkg install ${DEPS} ${DEPSOPTIONAL};
+        tginit "${TGUSER}" "${TGPASS}" "${WGINTERFACE}" "${WGIFNR}" "${NOHOSTROUTE}" "${LISTENPORT}" "${MTU}" "${FWMARK}" "${KEEPALIVE}" "${DELEGATE}" "${ROUTEALLOWEDIPS}" "${FIREWALLZONE}" "${WGPRIVKEY}" "${ENDPOINT}:${ENPOINTPORT}";;
   n|N ) echo "user abort, script finished"; exit;;
   * ) echo "${INVALIDCHOICEMSG1}"; exit;;
 esac


### PR DESCRIPTION
- add IP check before and after connection with VPN
- add option to hide passwords when pasting it, deafault is disabled
- add function to create public and api keys from config
- add demo script running with selected settings
- use curl, wget is still available for usage but should not be used as it results in errors with new TG api (**TODO**)
- add new options to torguard config
  - tgprivkey
  - wgapipubkey
  - upgrade

# Fixes
- fix and adapt to new TorGuard api changes
  - automatic generation of keys is only used if private key is unset in conf file
  - script requires a user to user keys created by TG client or with TG Wireguard tool on your account
- fix keepalive issue
- fix APIPUBKEY generation during initialization phase and save it in conf file
- fix tginit to use
- fix dbin usage in init script
- minor fixes and cleanup